### PR TITLE
chore(ci): Target Rust stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: rust
-rust: nightly
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: beta
+    - rust: nightly
+  fast_finish: true
+
 cache: cargo
 
 services:


### PR DESCRIPTION
Target Rust stable, optimistically test beta & nightly

From: [TravisCI doc - Choosing a Rust version](https://docs.travis-ci.com/user/languages/rust/#Choosing-a-Rust-version)