### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ rustup default nightly
 
 # start postgresql and seed the database
 psql -f init.sql
-cargo install diesel_cli
+cargo install diesel_cli --no-default-features --features "postgres"
 diesel migration run
 
 cargo run


### PR DESCRIPTION
Cargo by default install `diesel_cli` for various database engines. Without having those database engines installed first, the installation will fail. The example only requires PostgreSQL as the database, so `diesel_cli` should be installed for PostgreSQL only.