### PR TITLE
Use rust-toolchain file to specify nightly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,6 @@ Install [nightly](https://www.rust-lang.org/en-US/install.html)
 curl https://sh.rustup.rs -sSf | sh
 
 rustup install nightly
-rustup default nightly
 
 # start postgresql and seed the database
 psql -f init.sql

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Rather than requiring the user set nightly as the default, or configure rustup to use nightly Rust for this project, you can use the `rust-toolchain` file to take care of it for them. 