### PR TITLE
refact: unique username validation moved to db, and added unique email

### DIFF
--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -1,10 +1,10 @@
 use crate::models::user::User;
 use crate::schema::users;
 use crypto::scrypt::{scrypt_check, scrypt_simple, ScryptParams};
+use diesel::dsl::{exists, select};
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use serde::Deserialize;
-use diesel::dsl::{exists, select};
 
 #[allow(unused_variables)]
 pub fn username_exists(conn: &PgConnection, username: &str) -> bool {
@@ -22,8 +22,6 @@ pub fn email_exists(conn: &PgConnection, email: &str) -> bool {
         .get_result(conn)
         .expect("exist email")
 }
-
-
 
 #[derive(Insertable)]
 #[table_name = "users"]

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -6,23 +6,6 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use serde::Deserialize;
 
-#[allow(unused_variables)]
-pub fn username_exists(conn: &PgConnection, username: &str) -> bool {
-    use self::users::dsl::*;
-    let username_exists = select(exists(users.filter(username.eq(username))))
-        .get_result(conn)
-        .expect("exist username");
-    username_exists
-}
-
-#[allow(unused_variables)]
-pub fn email_exists(conn: &PgConnection, email: &str) -> bool {
-    use self::users::dsl::*;
-    select(exists(users.filter(email.eq(email))))
-        .get_result(conn)
-        .expect("exist email")
-}
-
 #[derive(Insertable)]
 #[table_name = "users"]
 pub struct NewUser<'a> {
@@ -100,4 +83,16 @@ pub fn update(conn: &PgConnection, id: i32, data: &UpdateUserData) -> Option<Use
         .set(data)
         .get_result(conn)
         .ok()
+}
+
+pub fn username_exists(conn: &PgConnection, username: &str) -> bool {
+    select(exists(users::table.filter(users::username.eq(username))))
+        .get_result(conn)
+        .expect("exist username")
+}
+
+pub fn email_exists(conn: &PgConnection, email: &str) -> bool {
+    select(exists(users::table.filter(users::email.eq(email))))
+        .get_result(conn)
+        .expect("exist email")
 }

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -1,35 +1,26 @@
 use crate::models::user::User;
 use crate::schema::users;
 use crypto::scrypt::{scrypt_check, scrypt_simple, ScryptParams};
-use diesel;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use serde::Deserialize;
+use diesel::dsl::{exists, select};
 
-
-pub fn validate_unique_username(conn: &PgConnection, username: &str) -> Result<(), ()> {
-    use crate::schema::users;
-    let n: i64 = users::table
-        .filter(users::username.eq(&username))
-        .count()
+#[allow(unused_variables)]
+pub fn username_exists(conn: &PgConnection, username: &str) -> bool {
+    use self::users::dsl::*;
+    let username_exists = select(exists(users.filter(username.eq(username))))
         .get_result(conn)
-        .expect("count username");
-    if n > 0 {
-        return Err(());
-    }
-    Ok(())
+        .expect("exist username");
+    username_exists
 }
-pub fn validate_unique_email(conn: &PgConnection, email: &str) -> Result<(), ()> {
-    use crate::schema::users;
-    let n: i64 = users::table
-        .filter(users::email.eq(&email))
-        .count()
+
+#[allow(unused_variables)]
+pub fn email_exists(conn: &PgConnection, email: &str) -> bool {
+    use self::users::dsl::*;
+    select(exists(users.filter(email.eq(email))))
         .get_result(conn)
-        .expect("count email");
-    if n > 0 {
-        return Err(());
-    }
-    Ok(())
+        .expect("exist email")
 }
 
 

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -6,6 +6,34 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use serde::Deserialize;
 
+
+pub fn validate_unique_username(conn: &PgConnection, username: &str) -> Result<(), ()> {
+    use crate::schema::users;
+    let n: i64 = users::table
+        .filter(users::username.eq(&username))
+        .count()
+        .get_result(conn)
+        .expect("count username");
+    if n > 0 {
+        return Err(());
+    }
+    Ok(())
+}
+pub fn validate_unique_email(conn: &PgConnection, email: &str) -> Result<(), ()> {
+    use crate::schema::users;
+    let n: i64 = users::table
+        .filter(users::email.eq(&email))
+        .count()
+        .get_result(conn)
+        .expect("count email");
+    if n > 0 {
+        return Err(());
+    }
+    Ok(())
+}
+
+
+
 #[derive(Insertable)]
 #[table_name = "users"]
 pub struct NewUser<'a> {

--- a/src/routes/articles.rs
+++ b/src/routes/articles.rs
@@ -150,5 +150,6 @@ pub fn get_articles_feed(
     conn: db::Conn,
 ) -> Json<JsonValue> {
     let articles = db::articles::feed(&conn, &params, auth.id);
-    Json(json!({ "articles": articles }))
+    let articles_count = articles.len();
+    Json(json!({ "articles": articles, "articlesCount": articles_count }))
 }

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -30,10 +30,10 @@ pub fn post_users(new_user: Json<NewUser>, conn: db::Conn) -> Result<Json<JsonVa
     let email = extractor.extract("email", new_user.email);
     let password = extractor.extract("password", new_user.password);
 
-    if username_exists(&conn, &username){
-       extractor.add_error("username", "has already been taken");
+    if username_exists(&conn, &username) {
+        extractor.add_error("username", "has already been taken");
     }
-     if email_exists(&conn, &email){
+    if email_exists(&conn, &email) {
         extractor.add_error("email", "has already been taken");
     }
     extractor.check()?;

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -1,7 +1,6 @@
 use crate::auth::Auth;
-use crate::db;
+use crate::db::{self, users::{email_exists, username_exists}};
 use crate::errors::{Errors, FieldValidator};
-use db::users::{email_exists, username_exists};
 
 use rocket_contrib::json::{Json, JsonValue};
 use serde::Deserialize;
@@ -36,6 +35,7 @@ pub fn post_users(new_user: Json<NewUser>, conn: db::Conn) -> Result<Json<JsonVa
     if email_exists(&conn, &email) {
         extractor.add_error("email", "has already been taken");
     }
+
     extractor.check()?;
 
     let user = db::users::create(&conn, &username, &email, &password);


### PR DESCRIPTION
Previously when a repeated email was entered for a new user, the
application ended with a panic, now this unique constraint is validated,
the email unique validation and username validation was moved to
two new functions in db::users