### PR TITLE
feat: Article author in api set to profile

### DIFF
--- a/src/db/profiles.rs
+++ b/src/db/profiles.rs
@@ -12,14 +12,12 @@ pub fn find(conn: &PgConnection, name: &str, user_id: Option<i32>) -> Option<Pro
         .map_err(|err| println!("find_user_by_name: {}", err))
         .ok()?;
 
-    let following = user_id
-        .map(|id| is_following(conn, &user, id))
-        .unwrap_or(false);
+    let following = user_id.map_or(false, |id| is_following(conn, &user, id));
 
     Some(user.to_profile(following))
 }
 
-fn is_following(conn: &PgConnection, user: &User, user_id: i32) -> bool {
+pub fn is_following(conn: &PgConnection, user: &User, user_id: i32) -> bool {
     use diesel::dsl::exists;
     use diesel::select;
 

--- a/src/models/article.rs
+++ b/src/models/article.rs
@@ -1,8 +1,7 @@
 use crate::config::DATE_FORMAT;
-use crate::models::user::User;
+use crate::models::user::Profile;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-
 #[derive(Queryable)]
 pub struct Article {
     pub id: i32,
@@ -18,7 +17,7 @@ pub struct Article {
 }
 
 impl Article {
-    pub fn attach(self, author: User, favorited: bool) -> ArticleJson {
+    pub fn attach(self, author: Profile, favorited: bool) -> ArticleJson {
         ArticleJson {
             id: self.id,
             slug: self.slug,
@@ -43,7 +42,7 @@ pub struct ArticleJson {
     pub title: String,
     pub description: String,
     pub body: String,
-    pub author: User,
+    pub author: Profile,
     pub tag_list: Vec<String>,
     pub created_at: String,
     pub updated_at: String,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,7 +1,7 @@
 use crate::auth::Auth;
 use chrono::{Duration, Utc};
+use diesel::PgConnection;
 use serde::Serialize;
-
 type Url = String;
 
 #[derive(Queryable, Serialize)]
@@ -50,8 +50,38 @@ impl User {
             token,
         }
     }
-
     pub fn to_profile(self, following: bool) -> Profile {
+        Profile {
+            username: self.username,
+            bio: self.bio,
+            image: self.image,
+            following,
+        }
+    }
+    /// Return a `Profile` adding the `following` propertyfor a given `user_id`. If `None`
+    /// `user_id` is given, the following option of profile always take `false`
+    ///
+    /// # Examples
+    ///
+    /// When `Some` `user_id` is given, the following is checked at the database
+    ///
+    /// ```rust
+    /// # use diesel::PgConnection;
+    /// let user_profile: Profile = user.to_profile_for(conn, Some(7));
+    /// assert_eq!(user_profile.following, true);
+    /// ```
+    ///
+    /// When `None` `user_id` is given, always the `following` property of the `Profile` returned
+    /// is false
+    ///
+    /// ```rust
+    /// # use diesel::PgConnection;
+    /// let user_profile: Profile = user.to_profile_for(conn, None);
+    /// assert_eq!(user_profile.following, false);
+    /// ```
+    pub fn to_profile_for(self, conn: &PgConnection, user_id: Option<i32>) -> Profile {
+        use crate::db::profiles::is_following;
+        let following = user_id.map_or(false, |user_id| is_following(conn, &self, user_id));
         Profile {
             username: self.username,
             bio: self.bio,

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -1,5 +1,8 @@
 use crate::auth::Auth;
-use crate::db::{self, users::{email_exists, username_exists}};
+use crate::db::{
+    self,
+    users::{email_exists, username_exists},
+};
 use crate::errors::{Errors, FieldValidator};
 
 use rocket_contrib::json::{Json, JsonValue};


### PR DESCRIPTION
The definition of real-world models indicates that the author of the
article must be a `Profile` type object, before this was a` User` type,
additionally the functionality has been created to add the `following`
property to the author of the article, depending on whether the article
is created, or if this is obtained from the feed the behavior for the
`following` property of the author of the article changes.