### PR TITLE
Funct for get a Profile belonging to a User moved to db module and some style updates

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -32,8 +32,7 @@ impl Auth {
 
 impl<'a, 'r> FromRequest<'a, 'r> for Auth {
     type Error = ();
-
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<Auth, ()> {
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Auth, Self::Error> {
         if let Some(auth) = extract_auth_from_request(request) {
             Outcome::Success(auth)
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 /// js toISOString() in test suit can't handle chrono's default precision
-pub const DATE_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%.3fZ";
+pub const DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3fZ";
 
-pub const SECRET: &'static str = "secret123";
-pub const TOKEN_PREFIX: &'static str = "Token ";
+pub const SECRET: &str = "secret123";
+pub const TOKEN_PREFIX: &str = "Token ";

--- a/src/db/articles.rs
+++ b/src/db/articles.rs
@@ -1,4 +1,5 @@
 use crate::db::profiles::is_following;
+use crate::db::users::to_profile_for;
 use crate::models::article::{Article, ArticleJson};
 use crate::models::user::User;
 use crate::schema::articles;
@@ -124,7 +125,7 @@ pub fn find(conn: &PgConnection, params: &FindArticles, user_id: Option<i32>) ->
         .expect("Cannot load articles")
         .into_iter()
         .map(|(article, author, favorited)| {
-            article.attach(author.to_profile_for(conn, user_id), favorited)
+            article.attach(to_profile_for(conn, &author, user_id), favorited)
         })
         .collect()
 }
@@ -176,7 +177,7 @@ pub fn feed(conn: &PgConnection, params: &FeedArticles, user_id: i32) -> Vec<Art
         .expect("Cannot load feed")
         .into_iter()
         .map(|(article, author, favorited)| {
-            article.attach(author.to_profile_for(conn, Some(user_id)), favorited)
+            article.attach(to_profile_for(conn, &author, Some(user_id)), favorited)
         })
         .collect()
 }

--- a/src/db/articles.rs
+++ b/src/db/articles.rs
@@ -24,7 +24,7 @@ struct NewArticle<'a> {
     body: &'a str,
     slug: &'a str,
     author: i32,
-    tag_list: &'a Vec<String>,
+    tag_list: &'a [String],
 }
 
 pub fn create(
@@ -33,7 +33,7 @@ pub fn create(
     title: &str,
     description: &str,
     body: &str,
-    tag_list: &Vec<String>,
+    tag_list: &[String],
 ) -> ArticleJson {
     let new_article = &NewArticle {
         title,

--- a/src/db/articles.rs
+++ b/src/db/articles.rs
@@ -223,7 +223,7 @@ pub struct UpdateArticleData {
     #[serde(skip)]
     slug: Option<String>,
     #[serde(rename = "tagList")]
-    tag_list: Vec<String>,
+    tag_list: Option<Vec<String>>,
 }
 
 pub fn update(

--- a/src/db/comments.rs
+++ b/src/db/comments.rs
@@ -36,10 +36,14 @@ pub fn create(conn: &PgConnection, author: i32, slug: &str, body: &str) -> Comme
         .values(new_comment)
         .get_result::<Comment>(conn)
         .expect("Error creating comment")
-        .attach(author)
+        .attach(author.to_profile(false))
 }
 
-pub fn find_by_slug(conn: &PgConnection, slug: &str) -> Vec<CommentJson> {
+pub fn find_by_slug(
+    conn: &PgConnection,
+    slug: &str,
+    current_user_id: Option<i32>,
+) -> Vec<CommentJson> {
     let result = comments::table
         .inner_join(articles::table)
         .inner_join(users::table)
@@ -50,7 +54,7 @@ pub fn find_by_slug(conn: &PgConnection, slug: &str) -> Vec<CommentJson> {
 
     result
         .into_iter()
-        .map(|(comment, author)| comment.attach(author))
+        .map(|(comment, author)| comment.attach(author.to_profile_for(conn, current_user_id)))
         .collect()
 }
 

--- a/src/db/comments.rs
+++ b/src/db/comments.rs
@@ -1,3 +1,4 @@
+use crate::db::users::to_profile_for;
 use crate::models::comment::{Comment, CommentJson};
 use crate::models::user::User;
 use crate::schema::articles;
@@ -54,7 +55,7 @@ pub fn find_by_slug(
 
     result
         .into_iter()
-        .map(|(comment, author)| comment.attach(author.to_profile_for(conn, current_user_id)))
+        .map(|(comment, author)| comment.attach(to_profile_for(conn, &author, current_user_id)))
         .collect()
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -44,7 +44,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for Conn {
     fn from_request(request: &'a Request<'r>) -> request::Outcome<Conn, Self::Error> {
         let pool = request.guard::<State<Pool>>()?;
         match pool.get() {
-            Ok(conn) => Outcome::Success(Conn { pooled_conn: conn }),
+            Ok(pooled_conn) => Outcome::Success(Conn { pooled_conn }),
             Err(_) => Outcome::Failure((Status::ServiceUnavailable, ())),
         }
     }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,11 +4,11 @@ pub mod profiles;
 pub mod users;
 
 use dotenv::dotenv;
+use std::env;
 use std::ops::Deref;
 
 use diesel::pg::PgConnection;
 use diesel::r2d2::{self, ConnectionManager};
-use std::env;
 
 use rocket::http::Status;
 use rocket::request::{self, FromRequest};

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -15,6 +15,7 @@ use rocket::request::{self, FromRequest};
 use rocket::{Outcome, Request, State};
 
 pub type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
+pub type PooledConnection = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
 
 pub fn init_pool() -> Pool {
     dotenv().ok();
@@ -24,7 +25,7 @@ pub fn init_pool() -> Pool {
     r2d2::Pool::new(manager).expect("db pool")
 }
 
-pub struct Conn(pub r2d2::PooledConnection<ConnectionManager<PgConnection>>);
+pub struct Conn(pub PooledConnection);
 
 impl Deref for Conn {
     type Target = PgConnection;
@@ -38,7 +39,7 @@ impl Deref for Conn {
 impl<'a, 'r> FromRequest<'a, 'r> for Conn {
     type Error = ();
 
-    fn from_request(request: &'a Request<'r>) -> request::Outcome<Conn, ()> {
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Conn, Self::Error> {
         let pool = request.guard::<State<Pool>>()?;
         match pool.get() {
             Ok(conn) => Outcome::Success(Conn(conn)),

--- a/src/db/profiles.rs
+++ b/src/db/profiles.rs
@@ -12,14 +12,12 @@ pub fn find(conn: &PgConnection, name: &str, user_id: Option<i32>) -> Option<Pro
         .map_err(|err| println!("find_user_by_name: {}", err))
         .ok()?;
 
-    let following = user_id
-        .map(|id| is_following(conn, &user, id))
-        .unwrap_or(false);
+    let following = user_id.map_or(false, |id| is_following(conn, &user, id));
 
     Some(user.to_profile(following))
 }
 
-fn is_following(conn: &PgConnection, user: &User, user_id: i32) -> bool {
+pub fn is_following(conn: &PgConnection, user: &User, user_id: i32) -> bool {
     use diesel::dsl::exists;
     use diesel::select;
 

--- a/src/models/article.rs
+++ b/src/models/article.rs
@@ -1,8 +1,7 @@
 use crate::config::DATE_FORMAT;
-use crate::models::user::User;
+use crate::models::user::Profile;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-
 #[derive(Queryable)]
 pub struct Article {
     pub id: i32,
@@ -18,7 +17,7 @@ pub struct Article {
 }
 
 impl Article {
-    pub fn attach(self, author: User, favorited: bool) -> ArticleJson {
+    pub fn attach(self, author: Profile, favorited: bool) -> ArticleJson {
         ArticleJson {
             id: self.id,
             slug: self.slug,
@@ -43,7 +42,7 @@ pub struct ArticleJson {
     pub title: String,
     pub description: String,
     pub body: String,
-    pub author: User,
+    pub author: Profile,
     pub tag_list: Vec<String>,
     pub created_at: String,
     pub updated_at: String,

--- a/src/models/comment.rs
+++ b/src/models/comment.rs
@@ -1,5 +1,5 @@
 use crate::config::DATE_FORMAT;
-use crate::models::user::User;
+use crate::models::user::Profile;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
@@ -14,7 +14,7 @@ pub struct Comment {
 }
 
 impl Comment {
-    pub fn attach(self, author: User) -> CommentJson {
+    pub fn attach(self, author: Profile) -> CommentJson {
         CommentJson {
             id: self.id,
             body: self.body,
@@ -30,7 +30,7 @@ impl Comment {
 pub struct CommentJson {
     pub id: i32,
     pub body: String,
-    pub author: User,
+    pub author: Profile,
     pub created_at: String,
     pub updated_at: String,
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,6 +1,5 @@
 use crate::auth::Auth;
 use chrono::{Duration, Utc};
-use diesel::PgConnection;
 use serde::Serialize;
 type Url = String;
 
@@ -31,6 +30,21 @@ pub struct Profile {
     image: Option<String>,
     following: bool,
 }
+impl Profile {
+    pub fn new(
+        username: String,
+        bio: Option<String>,
+        image: Option<String>,
+        following: bool,
+    ) -> Profile {
+        Profile {
+            username,
+            bio,
+            image,
+            following,
+        }
+    }
+}
 
 impl User {
     pub fn to_user_auth(&self) -> UserAuth {
@@ -51,37 +65,6 @@ impl User {
         }
     }
     pub fn to_profile(self, following: bool) -> Profile {
-        Profile {
-            username: self.username,
-            bio: self.bio,
-            image: self.image,
-            following,
-        }
-    }
-    /// Return a `Profile` adding the `following` propertyfor a given `user_id`. If `None`
-    /// `user_id` is given, the following option of profile always take `false`
-    ///
-    /// # Examples
-    ///
-    /// When `Some` `user_id` is given, the following is checked at the database
-    ///
-    /// ```rust
-    /// # use diesel::PgConnection;
-    /// let user_profile: Profile = user.to_profile_for(conn, Some(7));
-    /// assert_eq!(user_profile.following, true);
-    /// ```
-    ///
-    /// When `None` `user_id` is given, always the `following` property of the `Profile` returned
-    /// is false
-    ///
-    /// ```rust
-    /// # use diesel::PgConnection;
-    /// let user_profile: Profile = user.to_profile_for(conn, None);
-    /// assert_eq!(user_profile.following, false);
-    /// ```
-    pub fn to_profile_for(self, conn: &PgConnection, user_id: Option<i32>) -> Profile {
-        use crate::db::profiles::is_following;
-        let following = user_id.map_or(false, |user_id| is_following(conn, &self, user_id));
         Profile {
             username: self.username,
             bio: self.bio,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,7 +1,7 @@
 use crate::auth::Auth;
 use chrono::{Duration, Utc};
+use diesel::PgConnection;
 use serde::Serialize;
-
 type Url = String;
 
 #[derive(Queryable, Serialize)]
@@ -50,8 +50,38 @@ impl User {
             token,
         }
     }
-
     pub fn to_profile(self, following: bool) -> Profile {
+        Profile {
+            username: self.username,
+            bio: self.bio,
+            image: self.image,
+            following,
+        }
+    }
+    /// Return a `Profile` adding the `following` propertyfor a given `user_id`. If `None`
+    /// `user_id` is given, the following option of profile always take `false`
+    ///
+    /// # Examples
+    ///
+    /// When `Some` `user_id` is given, the following is checked at the database
+    ///
+    /// ```rust
+    /// # use diesel::PgConnection;
+    /// let user_profile: Profile = user.to_profile_for(conn, Some(7));
+    /// assert_eq!(user_profile.following, true);
+    /// ```
+    ///
+    /// When `None` `user_id` is given, always the `following` property of the `Profile` returned
+    /// is false
+    ///
+    /// ```rust
+    /// # use diesel::PgConnection;
+    /// let user_profile: Profile = user.to_profile_for(conn, None);
+    /// assert_eq!(user_profile.following, false);
+    /// ```
+    pub fn to_profile_for(self, conn: &PgConnection, user_id: Option<i32>) -> Profile {
+        use crate::db::profiles::is_following;
+        let following = user_id.map_or(false, |user_id| is_following(conn, &self, user_id));
         Profile {
             username: self.username,
             bio: self.bio,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -64,11 +64,11 @@ impl User {
             token,
         }
     }
-    pub fn to_profile(self, following: bool) -> Profile {
+    pub fn to_profile(&self, following: bool) -> Profile {
         Profile {
-            username: self.username,
-            bio: self.bio,
-            image: self.image,
+            username: self.username.clone(),
+            bio: self.bio.clone(),
+            image: self.image.clone(),
             following,
         }
     }

--- a/src/routes/articles.rs
+++ b/src/routes/articles.rs
@@ -138,8 +138,9 @@ pub fn delete_comment(slug: String, id: i32, auth: Auth, conn: db::Conn) {
 }
 
 #[get("/articles/<slug>/comments")]
-pub fn get_comments(slug: String, conn: db::Conn) -> Json<JsonValue> {
-    let comments = db::comments::find_by_slug(&conn, &slug);
+pub fn get_comments(slug: String, conn: db::Conn, auth: Option<Auth>) -> Json<JsonValue> {
+    let auth_id = auth.map_or(None, |auth| Some(auth.id));
+    let comments = db::comments::find_by_slug(&conn, &slug, auth_id);
     Json(json!({ "comments": comments }))
 }
 

--- a/src/routes/articles.rs
+++ b/src/routes/articles.rs
@@ -139,7 +139,7 @@ pub fn delete_comment(slug: String, id: i32, auth: Auth, conn: db::Conn) {
 
 #[get("/articles/<slug>/comments")]
 pub fn get_comments(slug: String, conn: db::Conn, auth: Option<Auth>) -> Json<JsonValue> {
-    let auth_id = auth.map_or(None, |auth| Some(auth.id));
+    let auth_id = auth.and_then(|auth| Some(auth.id));
     let comments = db::comments::find_by_slug(&conn, &slug, auth_id);
     Json(json!({ "comments": comments }))
 }

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -1,5 +1,8 @@
 use crate::auth::Auth;
-use crate::db::{self, users::{email_exists, username_exists}};
+use crate::db::{
+    self,
+    users::{email_exists, username_exists},
+};
 use crate::errors::{Errors, FieldValidator};
 
 use rocket_contrib::json::{Json, JsonValue};


### PR DESCRIPTION
Changes summary:

- [Clippy warnings fixed](https://github.com/luchoman08/realworld-rust-rocket/commit/4ebec7d01c06c22619c59d01e46f7f4e1b68a7b6).
- Minnor style changes at [here](https://github.com/luchoman08/realworld-rust-rocket/commit/e35bfb41f7c21d56159794146b150f292220c88b) and [here](https://github.com/luchoman08/realworld-rust-rocket/commit/20207bda7d0c2f457de4e67e2b38c26a9322b471)
- Redeability changes [here](https://github.com/luchoman08/realworld-rust-rocket/commit/7a7d3ccb97babe053c291d6b8af2e078470c4b39) and [here](https://github.com/TatriX/realworld-rust-rocket/commit/e41de0100427cbb0b3cfe1311b98b91b0b008069)
-  Moved function for return a profile based in a user from models (method of User) to db module [here](https://github.com/TatriX/realworld-rust-rocket/commit/6f1d5e084544bc74c19445f740ff66a7360f0922)

Posdata: All test from [here](https://github.com/gothinkster/realworld/tree/master/api) are passed 