### PR TITLE
fix: Removing debug assertion for release build

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::env;
 
 /// Debug only secret for JWT encoding & decoding.
-#[cfg(debug_assertions)]
 const SECRET: &'static str = "8Xui8SN4mI+7egV/9dlfYYLGQJeEx4+DwmSQLwDVXJg=";
 
 /// js toISOString() in test suit can't handle chrono's default precision


### PR DESCRIPTION
Having the debug assertion attribute means that they const is essentially invisible to the release compiler, which causes an error when building for release. 

```
if cfg!(debug_assertions) {
    SECRET.to_string()
}
```
Because you use `SECRET` in the code above, the compiler still needs to know the value of it, even if you and I both know it will not be accessed, as the release build will never enter that block.

Removing the attribute fixes the release build while keeping the same functionality.